### PR TITLE
Feat: Real Pluggy Open Banking integration

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -29,4 +29,4 @@ RUN SECRET_KEY=build-time-only python manage.py collectstatic --noinput
 EXPOSE 8000
 
 # Run the application
-CMD ["sh", "-c", "gunicorn config.wsgi:application --bind 0.0.0.0:${PORT:-8000}"]
+CMD ["sh", "-c", "gunicorn config.wsgi:application --bind 0.0.0.0:${PORT:-8000} --timeout 120"]

--- a/backend/apps/ai_services/services.py
+++ b/backend/apps/ai_services/services.py
@@ -1,5 +1,7 @@
+import hashlib
 import openai
 import os
+from decimal import Decimal
 from django.core.cache import cache
 from .models import AICache
 
@@ -33,7 +35,11 @@ class AIService:
 
     @staticmethod
     def categorize_transaction(description, amount):
-        cache_key = f"categorize_{description}_{amount}"
+        # Key on description + sign: income vs expense changes the meaning,
+        # magnitude rarely does (and would kill the cache hit rate).
+        sign = '+' if Decimal(str(amount)) >= 0 else '-'
+        digest = hashlib.sha256(f"{description}|{sign}".encode()).hexdigest()
+        cache_key = f"categorize:{digest}"
         try:
             cached_result = cache.get(cache_key)
             if cached_result:

--- a/backend/apps/ai_services/test_ai_services.py
+++ b/backend/apps/ai_services/test_ai_services.py
@@ -63,6 +63,48 @@ class AIServiceOutputValidationTests(TestCase):
             'gpt-4.1-mini')
 
 
+class CacheKeyTests(TestCase):
+    @patch('apps.ai_services.services.AICache')
+    @patch('apps.ai_services.services.cache')
+    @patch('apps.ai_services.services.openai.OpenAI')
+    def test_cache_key_is_cache_backend_safe(self, mock_openai, mock_cache, mock_ai_cache):
+        """Descriptions contain spaces/punctuation — the cache key must not
+        (memcached-incompatible and triggers CacheKeyWarning)."""
+        mock_cache.get.return_value = None
+        mock_queryset = MagicMock()
+        mock_queryset.first.return_value = None
+        mock_ai_cache.objects.filter.return_value = mock_queryset
+        _mock_openai_returning(mock_openai, 'Serviços')
+
+        with patch.dict(os.environ, {'OPENAI_API_KEY': 'test-key'}):
+            AIService.categorize_transaction('Pagamento de boleto', -100.00)
+
+        key = mock_cache.set.call_args.args[0]
+        self.assertNotIn(' ', key)
+        self.assertLess(len(key), 250)
+
+    @patch('apps.ai_services.services.AICache')
+    @patch('apps.ai_services.services.cache')
+    @patch('apps.ai_services.services.openai.OpenAI')
+    def test_cache_key_distinguishes_income_from_expense(self, mock_openai, mock_cache, mock_ai_cache):
+        """Same description with opposite signs (PIX in vs out) must not
+        share a cached category; magnitude alone must (cache hit rate)."""
+        mock_cache.get.return_value = None
+        mock_queryset = MagicMock()
+        mock_queryset.first.return_value = None
+        mock_ai_cache.objects.filter.return_value = mock_queryset
+        _mock_openai_returning(mock_openai, 'Outros')
+
+        with patch.dict(os.environ, {'OPENAI_API_KEY': 'test-key'}):
+            AIService.categorize_transaction('PIX TRANSFERENCIA', 5000.00)
+            AIService.categorize_transaction('PIX TRANSFERENCIA', -50.00)
+            AIService.categorize_transaction('PIX TRANSFERENCIA', -900.00)
+
+        keys = [c.args[0] for c in mock_cache.set.call_args_list]
+        self.assertNotEqual(keys[0], keys[1])
+        self.assertEqual(keys[1], keys[2])
+
+
 class CategorizeTaskTests(TestCase):
     @patch('apps.ai_services.tasks.AIService.categorize_transaction')
     def test_task_creates_category_with_list_keywords(self, mock_categorize):

--- a/backend/apps/banking/services.py
+++ b/backend/apps/banking/services.py
@@ -1,34 +1,106 @@
-import requests
 import os
-from django.conf import settings
+
+import requests
+from django.core.cache import cache
+
+
+class PluggyError(Exception):
+    """Raised when Pluggy is misconfigured or rejects a request."""
+
 
 class PluggyService:
     BASE_URL = 'https://api.pluggy.ai'
-    API_KEY = os.environ.get('PLUGGY_API_KEY')
+    API_KEY_CACHE_KEY = 'pluggy_api_key'
+    # Pluggy API keys live for 2 hours; refresh a little early.
+    API_KEY_CACHE_TTL = 100 * 60
+    REQUEST_TIMEOUT = 30
 
     @staticmethod
-    def get_headers():
-        return {
-            'X-API-KEY': PluggyService.API_KEY,
-            'Content-Type': 'application/json',
-        }
+    def _credentials():
+        client_id = os.environ.get('PLUGGY_CLIENT_ID')
+        client_secret = os.environ.get('PLUGGY_CLIENT_SECRET')
+        if not client_id or not client_secret:
+            raise PluggyError(
+                'PLUGGY_CLIENT_ID and PLUGGY_CLIENT_SECRET must be configured')
+        return client_id, client_secret
+
+    @staticmethod
+    def get_api_key(force_refresh=False):
+        if not force_refresh:
+            try:
+                cached = cache.get(PluggyService.API_KEY_CACHE_KEY)
+            except Exception:
+                cached = None
+            if cached:
+                return cached
+
+        client_id, client_secret = PluggyService._credentials()
+        response = requests.post(
+            f'{PluggyService.BASE_URL}/auth',
+            json={'clientId': client_id, 'clientSecret': client_secret},
+            timeout=PluggyService.REQUEST_TIMEOUT,
+        )
+        if response.status_code != 200:
+            raise PluggyError(f'Pluggy auth failed: HTTP {response.status_code}')
+        api_key = response.json()['apiKey']
+        try:
+            cache.set(PluggyService.API_KEY_CACHE_KEY, api_key,
+                      timeout=PluggyService.API_KEY_CACHE_TTL)
+        except Exception:
+            pass
+        return api_key
+
+    @staticmethod
+    def _request(method, path, params=None, json=None):
+        api_key = PluggyService.get_api_key()
+        response = requests.request(
+            method, f'{PluggyService.BASE_URL}{path}',
+            params=params, json=json,
+            headers={'X-API-KEY': api_key},
+            timeout=PluggyService.REQUEST_TIMEOUT,
+        )
+        if response.status_code in (401, 403):
+            api_key = PluggyService.get_api_key(force_refresh=True)
+            response = requests.request(
+                method, f'{PluggyService.BASE_URL}{path}',
+                params=params, json=json,
+                headers={'X-API-KEY': api_key},
+                timeout=PluggyService.REQUEST_TIMEOUT,
+            )
+        response.raise_for_status()
+        return response.json()
+
+    @staticmethod
+    def create_connect_token(client_user_id):
+        """Mint a 30-minute token for the Pluggy Connect widget, bound to
+        our user id so resulting items can be ownership-checked."""
+        data = PluggyService._request(
+            'POST', '/connect_token',
+            json={'options': {'clientUserId': str(client_user_id)}})
+        return data['accessToken']
+
+    @staticmethod
+    def get_item(item_id):
+        return PluggyService._request('GET', f'/items/{item_id}')
 
     @staticmethod
     def get_accounts(item_id):
-        url = f'{PluggyService.BASE_URL}/accounts'
-        params = {'itemId': item_id}
-        response = requests.get(url, params=params, headers=PluggyService.get_headers())
-        response.raise_for_status()
-        return response.json()
+        return PluggyService._request('GET', '/accounts', params={'itemId': item_id})
 
     @staticmethod
     def get_transactions(account_id, from_date, to_date):
-        url = f'{PluggyService.BASE_URL}/transactions'
-        params = {
-            'accountId': account_id,
-            'from': from_date,
-            'to': to_date,
-        }
-        response = requests.get(url, params=params, headers=PluggyService.get_headers())
-        response.raise_for_status()
-        return response.json()
+        """Return every transaction in the range, following pagination."""
+        rows = []
+        page = 1
+        while True:
+            data = PluggyService._request('GET', '/transactions', params={
+                'accountId': account_id,
+                'from': from_date,
+                'to': to_date,
+                'pageSize': 500,
+                'page': page,
+            })
+            rows.extend(data.get('results', []))
+            if page >= data.get('totalPages', 1):
+                return rows
+            page += 1

--- a/backend/apps/banking/tasks.py
+++ b/backend/apps/banking/tasks.py
@@ -1,0 +1,84 @@
+from datetime import date, datetime, timedelta, timezone as dt_timezone
+from decimal import Decimal
+
+from celery import shared_task
+from django.db import IntegrityError
+from django.utils import timezone
+from requests import RequestException
+
+from apps.ai_services.tasks import categorize_user_transactions
+from apps.transactions.models import Transaction
+from .models import BankAccount
+from .services import PluggyService
+
+DESCRIPTION_MAX_LENGTH = Transaction._meta.get_field("description").max_length
+
+
+def _parse_pluggy_datetime(value):
+    parsed = datetime.fromisoformat(value)
+    if timezone.is_naive(parsed):
+        parsed = parsed.replace(tzinfo=dt_timezone.utc)
+    return parsed
+
+
+# Transient Pluggy/network failures must not permanently lose the one-shot
+# 90-day backfill (the daily sync only re-fetches a 3-day window).
+@shared_task(
+    autoretry_for=(RequestException,),
+    retry_backoff=True,
+    retry_backoff_max=600,
+    retry_jitter=True,
+    max_retries=5,
+)
+def sync_account_transactions(account_id, start_date=None, end_date=None):
+    """Import transactions for one account, defaulting to the last 90 days,
+    then hand the new rows to AI categorization."""
+    account = BankAccount.objects.filter(id=account_id, is_active=True).first()
+    if account is None:
+        return f"Account {account_id} not found or inactive"
+
+    end_date = end_date or date.today().isoformat()
+    start_date = (
+        start_date or (date.fromisoformat(end_date) - timedelta(days=90)).isoformat()
+    )
+
+    created = 0
+    for row in PluggyService.get_transactions(
+        account.pluggy_account_id, start_date, end_date
+    ):
+        try:
+            _, was_created = Transaction.objects.get_or_create(
+                pluggy_transaction_id=row["id"],
+                defaults={
+                    "account": account,
+                    "amount": Decimal(str(row["amount"])),
+                    "description": (row.get("description") or "")[:DESCRIPTION_MAX_LENGTH],
+                    "date": _parse_pluggy_datetime(row["date"]),
+                },
+            )
+        except IntegrityError:
+            # A concurrent sync inserted this row between our get and create.
+            continue
+        if was_created:
+            created += 1
+
+    if created:
+        try:
+            categorize_user_transactions.delay(account.user_id)
+        except Exception:
+            # Broker down — rows are imported; categorisation can run later.
+            pass
+
+    return f"{created} transactions imported for account {account_id}"
+
+
+@shared_task
+def sync_all_active_accounts():
+    """Daily incremental sync: re-fetch a 3-day window per active account
+    to pick up late-posting transactions."""
+    start_date = (date.today() - timedelta(days=3)).isoformat()
+    enqueued = 0
+    for account in BankAccount.objects.filter(is_active=True).iterator():
+        sync_account_transactions.delay(account.id, start_date=start_date)
+        enqueued += 1
+    return f"Sync enqueued for {enqueued} accounts"

--- a/backend/apps/banking/test_banking.py
+++ b/backend/apps/banking/test_banking.py
@@ -1,56 +1,471 @@
-from unittest.mock import patch
+import os
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
 
+import requests as requests_lib
+from django.test import TestCase, override_settings
 from django.urls import reverse
+from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.test import APITestCase
 from django.contrib.auth import get_user_model
 from apps.transactions.models import Transaction
 from .models import BankAccount
+from .services import PluggyError, PluggyService
+from .tasks import sync_account_transactions, sync_all_active_accounts
 
 User = get_user_model()
 
-class FetchTransactionsTests(APITestCase):
+
+def _response(status_code=200, payload=None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = payload or {}
+    return resp
+
+
+class PluggyServiceTests(TestCase):
+    """The real Pluggy auth model: clientId/clientSecret are exchanged at
+    POST /auth for a short-lived API key, cached and refreshed on expiry."""
+
+    def setUp(self):
+        self.env = patch.dict(os.environ, {
+            'PLUGGY_CLIENT_ID': 'cid',
+            'PLUGGY_CLIENT_SECRET': 'csec',
+        })
+        self.env.start()
+        self.addCleanup(self.env.stop)
+
+    @patch('apps.banking.services.cache')
+    @patch('apps.banking.services.requests')
+    def test_get_api_key_exchanges_client_credentials(self, mock_requests, mock_cache):
+        mock_cache.get.return_value = None
+        mock_requests.post.return_value = _response(200, {'apiKey': 'fresh-key'})
+
+        key = PluggyService.get_api_key()
+
+        self.assertEqual(key, 'fresh-key')
+        args, kwargs = mock_requests.post.call_args
+        self.assertIn('/auth', args[0])
+        self.assertEqual(kwargs['json'], {'clientId': 'cid', 'clientSecret': 'csec'})
+        mock_cache.set.assert_called_once()
+
+    @patch('apps.banking.services.cache')
+    @patch('apps.banking.services.requests')
+    def test_get_api_key_reuses_cached_key(self, mock_requests, mock_cache):
+        mock_cache.get.return_value = 'cached-key'
+
+        key = PluggyService.get_api_key()
+
+        self.assertEqual(key, 'cached-key')
+        mock_requests.post.assert_not_called()
+
+    @patch('apps.banking.services.cache')
+    @patch('apps.banking.services.requests')
+    def test_get_api_key_survives_cache_backend_failure(self, mock_requests, mock_cache):
+        """Redis being down must not break Pluggy calls."""
+        mock_cache.get.side_effect = Exception('redis down')
+        mock_cache.set.side_effect = Exception('redis down')
+        mock_requests.post.return_value = _response(200, {'apiKey': 'fresh-key'})
+
+        self.assertEqual(PluggyService.get_api_key(), 'fresh-key')
+
+    def test_missing_credentials_raise_pluggy_error(self):
+        with patch.dict(os.environ, {'PLUGGY_CLIENT_ID': '', 'PLUGGY_CLIENT_SECRET': ''}):
+            with self.assertRaises(PluggyError):
+                PluggyService.get_api_key()
+
+    @patch('apps.banking.services.cache')
+    @patch('apps.banking.services.requests')
+    def test_expired_api_key_is_refreshed_transparently(self, mock_requests, mock_cache):
+        """A 401/403 from Pluggy means the cached key expired: mint a new
+        one and retry the request once."""
+        mock_cache.get.return_value = 'stale-key'
+        mock_requests.post.return_value = _response(200, {'apiKey': 'new-key'})
+        mock_requests.request.side_effect = [
+            _response(401, {'message': 'expired'}),
+            _response(200, {'results': [{'id': 'acc-1'}]}),
+        ]
+
+        data = PluggyService.get_accounts('item-1')
+
+        self.assertEqual(data['results'][0]['id'], 'acc-1')
+        mock_requests.post.assert_called_once()
+        second_headers = mock_requests.request.call_args_list[1].kwargs['headers']
+        self.assertEqual(second_headers['X-API-KEY'], 'new-key')
+
+    @patch('apps.banking.services.cache')
+    @patch('apps.banking.services.requests')
+    def test_get_transactions_follows_pagination(self, mock_requests, mock_cache):
+        mock_cache.get.return_value = 'key'
+        mock_requests.request.side_effect = [
+            _response(200, {'results': [{'id': 'tx-1'}], 'page': 1, 'totalPages': 2}),
+            _response(200, {'results': [{'id': 'tx-2'}], 'page': 2, 'totalPages': 2}),
+        ]
+
+        rows = PluggyService.get_transactions('acc-1', '2026-03-14', '2026-06-12')
+
+        self.assertEqual([r['id'] for r in rows], ['tx-1', 'tx-2'])
+        pages = [c.kwargs['params']['page'] for c in mock_requests.request.call_args_list]
+        self.assertEqual(pages, [1, 2])
+
+    @patch('apps.banking.services.cache')
+    @patch('apps.banking.services.requests')
+    def test_create_connect_token_scopes_to_user(self, mock_requests, mock_cache):
+        mock_cache.get.return_value = 'key'
+        mock_requests.request.return_value = _response(200, {'accessToken': 'widget-token'})
+
+        token = PluggyService.create_connect_token(client_user_id=42)
+
+        self.assertEqual(token, 'widget-token')
+        call = mock_requests.request.call_args
+        self.assertIn('/connect_token', call.args[1])
+        # Pluggy requires clientUserId nested under 'options' — sent top-level
+        # it is silently ignored and the item carries clientUserId=null,
+        # which makes our ownership check reject the user's own item.
+        self.assertEqual(call.kwargs['json'], {'options': {'clientUserId': '42'}})
+
+
+class ConnectTokenViewTests(APITestCase):
     def setUp(self):
         self.user = User.objects.create_user(
-            email='test@example.com',
-            password='password123'
-        )
+            email='test@example.com', password='Tr0car-Forte#2026')
+        self.client.force_authenticate(user=self.user)
+        self.url = reverse('banking:connect_token')
+
+    @patch('apps.banking.views.PluggyService.create_connect_token')
+    def test_returns_widget_token_scoped_to_requesting_user(self, mock_token):
+        mock_token.return_value = 'widget-token'
+
+        response = self.client.post(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {'accessToken': 'widget-token'})
+        mock_token.assert_called_once_with(client_user_id=str(self.user.id))
+
+    def test_requires_authentication(self):
+        self.client.force_authenticate(user=None)
+        response = self.client.post(self.url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    @patch('apps.banking.views.PluggyService.create_connect_token')
+    def test_pluggy_failure_maps_to_502(self, mock_token):
+        mock_token.side_effect = PluggyError('credentials rejected')
+        response = self.client.post(self.url)
+        self.assertEqual(response.status_code, status.HTTP_502_BAD_GATEWAY)
+
+
+class ConnectBankAccountTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email='test@example.com', password='Tr0car-Forte#2026')
+        self.client.force_authenticate(user=self.user)
+        self.url = reverse('banking:connect_bank_account')
+        self.accounts_payload = {'results': [{
+            'id': 'pacc-1',
+            'name': 'Pluggy Bank',
+            'type': 'BANK',
+            'balance': 1234.56,
+        }]}
+
+    @patch('apps.banking.views.sync_account_transactions')
+    @patch('apps.banking.views.PluggyService')
+    def test_rejects_item_belonging_to_another_user(self, mock_service, mock_sync):
+        mock_service.get_item.return_value = {'id': 'item-1', 'clientUserId': '999'}
+
+        response = self.client.post(self.url, {'itemId': 'item-1'})
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(BankAccount.objects.count(), 0)
+        mock_service.get_accounts.assert_not_called()
+
+    @patch('apps.banking.views.sync_account_transactions')
+    @patch('apps.banking.views.PluggyService')
+    def test_connects_owned_item_and_enqueues_initial_sync(self, mock_service, mock_sync):
+        mock_service.get_item.return_value = {
+            'id': 'item-1', 'clientUserId': str(self.user.id)}
+        mock_service.get_accounts.return_value = self.accounts_payload
+
+        response = self.client.post(self.url, {'itemId': 'item-1'})
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        account = BankAccount.objects.get()
+        self.assertEqual(account.bank_name, 'Pluggy Bank')
+        self.assertEqual(account.user, self.user)
+        self.assertEqual(response.data['accounts'][0]['pluggy_account_id'], 'pacc-1')
+        self.assertTrue(response.data['sync_started'])
+        mock_sync.delay.assert_called_once_with(account.id)
+
+    @override_settings(DEBUG=True)
+    @patch('apps.banking.views.sync_account_transactions')
+    @patch('apps.banking.views.PluggyService')
+    def test_sync_runs_inline_when_broker_is_down(self, mock_service, mock_sync):
+        mock_service.get_item.return_value = {
+            'id': 'item-1', 'clientUserId': str(self.user.id)}
+        mock_service.get_accounts.return_value = self.accounts_payload
+        mock_sync.delay.side_effect = Exception('no broker')
+
+        response = self.client.post(self.url, {'itemId': 'item-1'})
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(response.data['sync_started'])
+        account = BankAccount.objects.get()
+        mock_sync.assert_called_once_with(account.id)
+
+    @override_settings(DEBUG=True)
+    @patch('apps.banking.views.sync_account_transactions')
+    @patch('apps.banking.views.PluggyService')
+    def test_inline_sync_failure_still_returns_created_accounts(self, mock_service, mock_sync):
+        """Accounts are persisted before syncing — a sync failure must not
+        turn the response into a 500 for a half-successful operation."""
+        mock_service.get_item.return_value = {
+            'id': 'item-1', 'clientUserId': str(self.user.id)}
+        mock_service.get_accounts.return_value = self.accounts_payload
+        mock_sync.delay.side_effect = Exception('no broker')
+        mock_sync.side_effect = requests_lib.HTTPError('pluggy 500')
+
+        response = self.client.post(self.url, {'itemId': 'item-1'})
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertFalse(response.data['sync_started'])
+        self.assertEqual(BankAccount.objects.count(), 1)
+
+    @override_settings(DEBUG=False)
+    @patch('apps.banking.views.sync_account_transactions')
+    @patch('apps.banking.views.PluggyService')
+    def test_no_inline_sync_in_production(self, mock_service, mock_sync):
+        """In production a 90-day import must never run inside the request
+        cycle (gunicorn worker timeout) — degrade to sync_started=False."""
+        mock_service.get_item.return_value = {
+            'id': 'item-1', 'clientUserId': str(self.user.id)}
+        mock_service.get_accounts.return_value = self.accounts_payload
+        mock_sync.delay.side_effect = Exception('no broker')
+
+        response = self.client.post(self.url, {'itemId': 'item-1'})
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertFalse(response.data['sync_started'])
+        mock_sync.assert_not_called()
+
+
+class FetchTransactionsViewTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email='test@example.com', password='Tr0car-Forte#2026')
         self.client.force_authenticate(user=self.user)
         self.account = BankAccount.objects.create(
             user=self.user,
             pluggy_account_id='test_account_id',
             bank_name='Test Bank',
             account_type='CHECKING',
-            balance=1000.00
+            balance=1000.00,
         )
-        self.fetch_url = reverse('banking:fetch_transactions', args=[self.account.id])
+        self.url = reverse('banking:fetch_transactions', args=[self.account.id])
 
-    @patch('apps.banking.views.PluggyService.get_transactions')
-    def test_fetch_saves_transactions_from_pluggy_results_key(self, mock_get_transactions):
-        """
-        Pluggy's GET /transactions returns rows under the 'results' key —
-        they must be parsed and saved.
-        """
-        mock_get_transactions.return_value = {
-            'results': [{
-                'id': 'pluggy-tx-1',
-                'amount': -54.90,
-                'description': 'IFOOD *RESTAURANTE',
-                'date': '2026-05-10T03:00:00.000Z',
-            }],
-            'total': 1,
-            'page': 1,
-            'totalPages': 1,
-        }
+    @patch('apps.banking.views.sync_account_transactions')
+    def test_enqueues_sync_with_requested_range(self, mock_sync):
+        mock_sync.delay.return_value = MagicMock(id='task-1')
+
         response = self.client.post(
-            self.fetch_url,
-            {'start_date': '2026-05-01', 'end_date': '2026-06-01'},
-        )
+            self.url, {'start_date': '2026-05-01', 'end_date': '2026-06-01'})
+
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        mock_sync.delay.assert_called_once_with(
+            self.account.id, start_date='2026-05-01', end_date='2026-06-01')
+
+    @patch('apps.banking.views.sync_account_transactions')
+    def test_dates_are_optional(self, mock_sync):
+        """Without an explicit range, the task defaults to the last 90 days."""
+        mock_sync.delay.return_value = MagicMock(id='task-1')
+
+        response = self.client.post(self.url, {})
+
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        mock_sync.delay.assert_called_once_with(
+            self.account.id, start_date=None, end_date=None)
+
+    @override_settings(DEBUG=True)
+    @patch('apps.banking.views.sync_account_transactions')
+    def test_runs_inline_when_broker_is_down(self, mock_sync):
+        mock_sync.delay.side_effect = Exception('no broker')
+        mock_sync.return_value = '3 transactions imported'
+
+        response = self.client.post(self.url, {})
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_sync.assert_called_once_with(
+            self.account.id, start_date=None, end_date=None)
+
+    def test_unknown_account_returns_404(self):
+        url = reverse('banking:fetch_transactions', args=[999])
+        response = self.client.post(url, {})
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @patch('apps.banking.views.sync_account_transactions')
+    def test_rejects_malformed_dates(self, mock_sync):
+        """User dates must be validated in the view — not crash the task."""
+        response = self.client.post(self.url, {'end_date': 'banana'})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('end_date', str(response.data))
+        mock_sync.delay.assert_not_called()
+        mock_sync.assert_not_called()
+
+    @override_settings(DEBUG=True)
+    @patch('apps.banking.views.sync_account_transactions')
+    def test_inline_failure_returns_502_not_500(self, mock_sync):
+        mock_sync.delay.side_effect = Exception('no broker')
+        mock_sync.side_effect = requests_lib.HTTPError('pluggy 500')
+        self.client.raise_request_exception = False
+
+        response = self.client.post(self.url, {})
+
+        self.assertEqual(response.status_code, status.HTTP_502_BAD_GATEWAY)
+
+    @override_settings(DEBUG=False)
+    @patch('apps.banking.views.sync_account_transactions')
+    def test_no_inline_fallback_in_production(self, mock_sync):
+        mock_sync.delay.side_effect = Exception('no broker')
+
+        response = self.client.post(self.url, {})
+
+        self.assertEqual(
+            response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        mock_sync.assert_not_called()
+
+
+class SyncAccountTransactionsTaskTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email='test@example.com', password='Tr0car-Forte#2026')
+        self.account = BankAccount.objects.create(
+            user=self.user,
+            pluggy_account_id='test_account_id',
+            bank_name='Test Bank',
+            account_type='CHECKING',
+            balance=1000.00,
+        )
+
+    @patch('apps.banking.tasks.categorize_user_transactions')
+    @patch('apps.banking.tasks.PluggyService')
+    def test_imports_last_90_days_with_decimal_amounts(self, mock_service, mock_categorize):
+        mock_service.get_transactions.return_value = [
+            {'id': 'tx-1', 'amount': -54.9, 'description': 'IFOOD *RESTAURANTE',
+             'date': '2026-05-10T03:00:00.000Z'},
+            {'id': 'tx-2', 'amount': 1200.5, 'description': 'PIX RECEBIDO',
+             'date': '2026-05-11T03:00:00.000Z'},
+        ]
+
+        with freeze_time('2026-06-12'):
+            sync_account_transactions(self.account.id)
+
+        mock_service.get_transactions.assert_called_once_with(
+            'test_account_id', '2026-03-14', '2026-06-12')
+        self.assertEqual(Transaction.objects.count(), 2)
+        tx = Transaction.objects.get(pluggy_transaction_id='tx-1')
+        self.assertEqual(tx.amount, Decimal('-54.9'))
+        mock_categorize.delay.assert_called_once_with(self.user.id)
+
+    @patch('apps.banking.tasks.categorize_user_transactions')
+    @patch('apps.banking.tasks.PluggyService')
+    def test_skips_already_imported_transactions(self, mock_service, mock_categorize):
+        Transaction.objects.create(
+            account=self.account, pluggy_transaction_id='tx-1', amount=-1,
+            description='old', date='2026-05-10T03:00:00+00:00')
+        mock_service.get_transactions.return_value = [
+            {'id': 'tx-1', 'amount': -54.9, 'description': 'IFOOD',
+             'date': '2026-05-10T03:00:00.000Z'},
+            {'id': 'tx-3', 'amount': -10.0, 'description': 'UBER',
+             'date': '2026-05-12T03:00:00.000Z'},
+        ]
+
+        sync_account_transactions(self.account.id)
+
+        self.assertEqual(Transaction.objects.count(), 2)
+        self.assertTrue(
+            Transaction.objects.filter(pluggy_transaction_id='tx-3').exists())
+
+    @patch('apps.banking.tasks.categorize_user_transactions')
+    @patch('apps.banking.tasks.PluggyService')
+    def test_no_categorization_when_nothing_imported(self, mock_service, mock_categorize):
+        mock_service.get_transactions.return_value = []
+
+        sync_account_transactions(self.account.id)
+
+        mock_categorize.delay.assert_not_called()
+
+    @patch('apps.banking.tasks.categorize_user_transactions')
+    @patch('apps.banking.tasks.PluggyService')
+    def test_categorization_broker_failure_does_not_break_sync(self, mock_service, mock_categorize):
+        mock_service.get_transactions.return_value = [
+            {'id': 'tx-1', 'amount': -5.0, 'description': 'X',
+             'date': '2026-05-10T03:00:00.000Z'},
+        ]
+        mock_categorize.delay.side_effect = Exception('no broker')
+
+        sync_account_transactions(self.account.id)  # must not raise
+
         self.assertEqual(Transaction.objects.count(), 1)
+
+    @patch('apps.banking.tasks.categorize_user_transactions')
+    @patch('apps.banking.tasks.PluggyService')
+    def test_duplicate_insert_race_does_not_abort_import(self, mock_service, mock_categorize):
+        """A concurrent sync inserting the same pluggy_transaction_id must
+        not kill this import mid-loop — remaining rows still land."""
+        from django.db import IntegrityError
+        mock_service.get_transactions.return_value = [
+            {'id': 'tx-1', 'amount': -5.0, 'description': 'A',
+             'date': '2026-05-10T03:00:00.000Z'},
+            {'id': 'tx-2', 'amount': -6.0, 'description': 'B',
+             'date': '2026-05-11T03:00:00.000Z'},
+        ]
+        real_tx = Transaction.objects.create(
+            account=self.account, pluggy_transaction_id='other', amount=-1,
+            description='x', date='2026-05-01T00:00:00+00:00')
+        with patch('apps.banking.tasks.Transaction.objects.get_or_create',
+                   side_effect=[IntegrityError('race'), (real_tx, True)]):
+            sync_account_transactions(self.account.id)  # must not raise
+
+    def test_sync_task_retries_on_transient_pluggy_errors(self):
+        """Transient Pluggy/network failures must not permanently lose the
+        one-shot 90-day backfill — the task retries with backoff."""
+        self.assertIn(
+            requests_lib.RequestException, sync_account_transactions.autoretry_for)
+        self.assertTrue(sync_account_transactions.retry_backoff)
+        self.assertGreaterEqual(sync_account_transactions.max_retries, 3)
+
+    @patch('apps.banking.tasks.categorize_user_transactions')
+    @patch('apps.banking.tasks.PluggyService')
+    def test_truncates_descriptions_to_model_limit(self, mock_service, mock_categorize):
+        mock_service.get_transactions.return_value = [
+            {'id': 'tx-1', 'amount': -5.0, 'description': 'X' * 300,
+             'date': '2026-05-10T03:00:00.000Z'},
+        ]
+
+        sync_account_transactions(self.account.id)
+
         tx = Transaction.objects.get()
-        self.assertEqual(tx.pluggy_transaction_id, 'pluggy-tx-1')
-        self.assertEqual(tx.description, 'IFOOD *RESTAURANTE')
+        self.assertEqual(len(tx.description), 200)
+
+
+class SyncAllActiveAccountsTaskTests(TestCase):
+    @patch('apps.banking.tasks.sync_account_transactions')
+    def test_enqueues_incremental_sync_only_for_active_accounts(self, mock_sync):
+        user = User.objects.create_user(
+            email='test@example.com', password='Tr0car-Forte#2026')
+        active = BankAccount.objects.create(
+            user=user, pluggy_account_id='acc-active', bank_name='B',
+            account_type='CHECKING', balance=0)
+        BankAccount.objects.create(
+            user=user, pluggy_account_id='acc-inactive', bank_name='B',
+            account_type='CHECKING', balance=0, is_active=False)
+
+        with freeze_time('2026-06-12'):
+            sync_all_active_accounts()
+
+        mock_sync.delay.assert_called_once_with(
+            active.id, start_date='2026-06-09')
+
 
 class BankingTests(APITestCase):
     def setUp(self):

--- a/backend/apps/banking/urls.py
+++ b/backend/apps/banking/urls.py
@@ -5,6 +5,7 @@ app_name = 'banking'
 
 urlpatterns = [
     path('accounts/', views.list_bank_accounts, name='list_bank_accounts'),
+    path('connect-token/', views.create_connect_token, name='connect_token'),
     path('accounts/connect/', views.connect_bank_account, name='connect_bank_account'),
     path('accounts/<int:account_id>/disconnect/', views.disconnect_bank_account, name='disconnect_bank_account'),
     path('accounts/<int:account_id>/transactions/fetch/', views.fetch_transactions, name='fetch_transactions'),

--- a/backend/apps/banking/views.py
+++ b/backend/apps/banking/views.py
@@ -1,3 +1,6 @@
+from datetime import date
+
+from django.conf import settings
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
@@ -5,9 +8,7 @@ from rest_framework.response import Response
 from .models import BankAccount
 from .serializers import BankAccountSerializer, ConnectBankAccountSerializer
 from .services import PluggyService
-from apps.transactions.models import Transaction
-from apps.categories.models import Category
-from datetime import datetime
+from .tasks import sync_account_transactions
 
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
@@ -18,33 +19,78 @@ def list_bank_accounts(request):
 
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
+def create_connect_token(request):
+    """Token for the Pluggy Connect widget, bound to the requesting user."""
+    try:
+        token = PluggyService.create_connect_token(client_user_id=str(request.user.id))
+    except Exception:
+        return Response(
+            {'error': 'Could not create a bank connection token'},
+            status=status.HTTP_502_BAD_GATEWAY)
+    return Response({'accessToken': token})
+
+@api_view(['POST'])
+@permission_classes([IsAuthenticated])
 def connect_bank_account(request):
     serializer = ConnectBankAccountSerializer(data=request.data)
-    if serializer.is_valid():
-        item_id = serializer.validated_data['itemId']
+    if not serializer.is_valid():
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    item_id = serializer.validated_data['itemId']
+    try:
+        item = PluggyService.get_item(item_id)
+    except Exception:
+        return Response({'error': 'Could not verify the bank connection'},
+                        status=status.HTTP_502_BAD_GATEWAY)
+
+    # Items are created through connect tokens carrying our user id —
+    # never import data from an item that belongs to someone else.
+    if item.get('clientUserId') != str(request.user.id):
+        return Response({'error': 'This bank connection does not belong to you'},
+                        status=status.HTTP_403_FORBIDDEN)
+
+    try:
+        accounts_data = PluggyService.get_accounts(item_id)
+    except Exception:
+        return Response({'error': 'Could not fetch accounts for this connection'},
+                        status=status.HTTP_502_BAD_GATEWAY)
+
+    created_accounts = []
+    for account_data in accounts_data.get('results', []):
+        bank_account, created = BankAccount.objects.update_or_create(
+            user=request.user,
+            pluggy_account_id=account_data['id'],
+            defaults={
+                'bank_name': account_data.get('name', 'Unknown'),
+                'account_type': account_data.get('type', 'OTHER'),
+                'balance': account_data.get('balance', 0),
+                'is_active': True,
+            }
+        )
+        created_accounts.append(bank_account)
+
+    # Accounts are persisted at this point: sync failures degrade to
+    # sync_started=False (recoverable via the fetch endpoint), never a 500.
+    sync_started = False
+    for bank_account in created_accounts:
         try:
-            accounts_data = PluggyService.get_accounts(item_id)
-            created_accounts = []
-            for account_data in accounts_data['results']:
-                bank_account, created = BankAccount.objects.update_or_create(
-                    user=request.user,
-                    pluggy_account_id=account_data['id'],
-                    defaults={
-                        'bank_name': account_data.get('name', 'Unknown'),
-                        'account_type': account_data.get('type', 'OTHER'),
-                        'balance': account_data.get('balance', 0),
-                        'is_active': True,
-                    }
-                )
-                created_accounts.append(bank_account)
+            sync_account_transactions.delay(bank_account.id)
+            sync_started = True
+        except Exception:
+            # Broker down. Importing inline is only acceptable in dev —
+            # in production the 90-day import would outlive the request.
+            if settings.DEBUG:
+                try:
+                    sync_account_transactions(bank_account.id)
+                    sync_started = True
+                except Exception:
+                    pass
 
-            response_serializer = BankAccountSerializer(created_accounts, many=True)
-            return Response(response_serializer.data, status=status.HTTP_201_CREATED)
-
-        except Exception as e:
-            return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
-
-    return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+    response_serializer = BankAccountSerializer(created_accounts, many=True)
+    return Response({
+        'accounts': response_serializer.data,
+        'sync_started': sync_started,
+    }, status=status.HTTP_201_CREATED)
 
 @api_view(['DELETE'])
 @permission_classes([IsAuthenticated])
@@ -65,33 +111,34 @@ def fetch_transactions(request, account_id):
     except BankAccount.DoesNotExist:
         return Response({'error': 'Bank account not found'}, status=status.HTTP_404_NOT_FOUND)
 
-    start_date = request.data.get('start_date')
-    end_date = request.data.get('end_date')
-
-    if not start_date or not end_date:
-        return Response({'error': 'start_date and end_date are required'}, status=status.HTTP_400_BAD_REQUEST)
+    start_date = request.data.get('start_date') or None
+    end_date = request.data.get('end_date') or None
+    for field, value in (('start_date', start_date), ('end_date', end_date)):
+        if value is not None:
+            try:
+                date.fromisoformat(str(value))
+            except (TypeError, ValueError):
+                return Response(
+                    {'error': f'{field} must be an ISO date (YYYY-MM-DD)'},
+                    status=status.HTTP_400_BAD_REQUEST)
 
     try:
-        pluggy_transactions = PluggyService.get_transactions(account.pluggy_account_id, start_date, end_date)
-
-        saved_transactions = []
-        for tx_data in pluggy_transactions.get('results', []):
-            # Check if transaction already exists
-            if not Transaction.objects.filter(pluggy_transaction_id=tx_data['id']).exists():
-                transaction = Transaction.objects.create(
-                    account=account,
-                    pluggy_transaction_id=tx_data['id'],
-                    amount=tx_data['amount'],
-                    description=tx_data['description'],
-                    date=datetime.fromisoformat(tx_data['date']),
-                    # Category will be set by AI later
-                )
-                saved_transactions.append(transaction)
-
+        task = sync_account_transactions.delay(
+            account.id, start_date=start_date, end_date=end_date)
         return Response({
-            'message': f'Successfully fetched {len(saved_transactions)} new transactions',
-            'transactions': len(saved_transactions)
-        }, status=status.HTTP_200_OK)
-
-    except Exception as e:
-        return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+            'message': 'Transaction sync started in background',
+            'task_id': task.id,
+        }, status=status.HTTP_202_ACCEPTED)
+    except Exception:
+        # Broker down. Inline import is dev-only (see connect_bank_account).
+        if not settings.DEBUG:
+            return Response(
+                {'error': 'Sync queue unavailable, try again later'},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE)
+        try:
+            result = sync_account_transactions(
+                account.id, start_date=start_date, end_date=end_date)
+        except Exception:
+            return Response({'error': 'Bank synchronization failed'},
+                            status=status.HTTP_502_BAD_GATEWAY)
+        return Response({'message': result}, status=status.HTTP_200_OK)

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -152,6 +152,18 @@ CELERY_ACCEPT_CONTENT = ['json']
 CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'
 CELERY_TIMEZONE = 'America/Sao_Paulo'
+# Fail fast when the broker is down so the views' fallback logic runs in
+# ~2s instead of ~19s of connection retries per .delay() call.
+CELERY_TASK_PUBLISH_RETRY = False
+CELERY_BROKER_CONNECTION_TIMEOUT = 2
+
+from celery.schedules import crontab
+CELERY_BEAT_SCHEDULE = {
+    'sync-bank-accounts-daily': {
+        'task': 'apps.banking.tasks.sync_all_active_accounts',
+        'schedule': crontab(hour=5, minute=0),
+    },
+}
 
 # Custom user model
 AUTH_USER_MODEL = 'authentication.CustomUser'

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -48,5 +48,15 @@ services:
       - redis
     environment: *app_env
 
+  celery_beat:
+    build: .
+    command: celery -A config beat --loglevel=info
+    volumes:
+      - .:/app
+    depends_on:
+      - db
+      - redis
+    environment: *app_env
+
 volumes:
   postgres_data:

--- a/tools/pluggy-connect/README.md
+++ b/tools/pluggy-connect/README.md
@@ -1,0 +1,22 @@
+# Pluggy Connect — sandbox test page
+
+Manual end-to-end test of the bank-connection flow: login → connect token →
+Pluggy Connect widget → account import → 90-day transaction sync.
+
+## Run
+
+The page must be served from an origin in the backend's CORS allowlist
+(`http://localhost:3000` or `http://localhost:5173` by default — opening the
+file directly via `file://` will fail at the login request):
+
+```bash
+# terminal 1 — backend
+cd backend && .venv/bin/python manage.py runserver
+
+# terminal 2 — this page
+cd tools/pluggy-connect && python3 -m http.server 5173
+```
+
+Open http://localhost:5173, log in with a Grana.AI user, and in the widget
+pick **Pluggy Bank** (sandbox): user `user-ok`, password `password-ok`,
+MFA `123456`.

--- a/tools/pluggy-connect/index.html
+++ b/tools/pluggy-connect/index.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Grana.AI — Teste de Conexão Bancária (sandbox)</title>
+  <style>
+    body { font-family: -apple-system, sans-serif; max-width: 640px; margin: 40px auto; padding: 0 16px; color: #222; }
+    h1 { font-size: 1.3rem; }
+    form { display: flex; gap: 8px; margin: 16px 0; }
+    input { flex: 1; padding: 10px; border: 1px solid #ccc; border-radius: 6px; }
+    button { padding: 10px 16px; border: 0; border-radius: 6px; background: #0a7d4f; color: #fff; font-weight: 600; cursor: pointer; }
+    pre { background: #f5f5f5; padding: 12px; border-radius: 6px; white-space: pre-wrap; min-height: 80px; }
+    .hint { color: #666; font-size: .85rem; }
+  </style>
+</head>
+<body>
+  <h1>Grana.AI — Conexão bancária via Pluggy Connect</h1>
+  <p class="hint">Faça login com um usuário do Grana.AI. No widget, escolha
+    <strong>Pluggy Bank</strong> (sandbox) e use <code>user-ok</code> /
+    <code>password-ok</code> (MFA: <code>123456</code>).</p>
+
+  <form id="login-form">
+    <input id="email" type="email" placeholder="email" required>
+    <input id="password" type="password" placeholder="senha" required>
+    <button>Entrar e conectar banco</button>
+  </form>
+  <pre id="log"></pre>
+
+  <script src="https://cdn.pluggy.ai/pluggy-connect/v2.8.2/pluggy-connect.js"></script>
+  <script>
+    const API = 'http://127.0.0.1:8000/api/v1';
+    const log = (m) => { document.getElementById('log').textContent += m + '\n'; };
+
+    document.getElementById('login-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      try {
+        const login = await fetch(`${API}/auth/login/`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            email: document.getElementById('email').value,
+            password: document.getElementById('password').value,
+          }),
+        });
+        if (!login.ok) { log('Login falhou: ' + await login.text()); return; }
+        const { tokens } = await login.json();
+        const auth = {
+          'Authorization': `Bearer ${tokens.access}`,
+          'Content-Type': 'application/json',
+        };
+        log('Login OK');
+
+        const ct = await fetch(`${API}/banking/connect-token/`, { method: 'POST', headers: auth });
+        if (!ct.ok) { log('Connect token falhou: ' + await ct.text()); return; }
+        const { accessToken } = await ct.json();
+        log('Connect token OK — abrindo widget Pluggy...');
+
+        const pluggyConnect = new PluggyConnect({
+          connectToken: accessToken,
+          includeSandbox: true,
+          onSuccess: async (itemData) => {
+            const itemId = itemData.item.id;
+            log(`Banco conectado! item=${itemId}`);
+            log(`  status=${itemData.item.status} execution=${itemData.item.executionStatus} clientUserId=${itemData.item.clientUserId}`);
+            log('Importando contas e os últimos 90 dias de transações...');
+            const resp = await fetch(`${API}/banking/accounts/connect/`, {
+              method: 'POST', headers: auth, body: JSON.stringify({ itemId }),
+            });
+            const body = await resp.json();
+            log(`HTTP ${resp.status}: ${JSON.stringify(body, null, 2)}`);
+
+            // With a Celery worker the sync is async — poll until the
+            // count stabilizes instead of reading it once.
+            let data = { count: 0, results: [] };
+            let previous = -1;
+            for (let i = 0; i < 8 && data.count !== previous; i++) {
+              previous = data.count;
+              await new Promise(r => setTimeout(r, 3000));
+              const txs = await fetch(`${API}/transactions/`, { headers: auth });
+              data = await txs.json();
+              log(`  transações até agora: ${data.count}`);
+            }
+            log(`Transações importadas: ${data.count}`);
+            (data.results || []).slice(0, 5).forEach(
+              t => log(`  ${t.date.slice(0, 10)}  ${t.amount}  ${t.description}`));
+          },
+          onError: (err) => log('Erro no widget: ' + JSON.stringify(err)),
+        });
+        pluggyConnect.init();
+      } catch (err) {
+        log('Erro: ' + err);
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Replaces the Phase-1 Pluggy stub (static API key, wrong response parsing, no way to
obtain an itemId) with the real, live-verified integration:

- **Auth lifecycle**: `clientId`/`clientSecret` exchanged at `POST /auth` for the
  2-hour API key — cached (100 min), transparently re-minted on 401/403, resilient
  to Redis being down.
- **`POST /api/v1/banking/connect-token/`**: mints 30-minute Pluggy Connect widget
  tokens bound to the requesting user (`options.clientUserId`).
- **Ownership binding**: `accounts/connect/` verifies the item's `clientUserId`
  matches the caller before importing — a user can no longer import someone
  else's bank data. Found live: Pluggy silently ignores a top-level
  `clientUserId` (it must be nested under `options`), which made the check
  correctly fail closed with 403 until fixed.
- **90-day sync** as a Celery task: paginated (`pageSize=500`), Decimal-safe,
  `get_or_create` dedup tolerant of concurrent runs, descriptions truncated to
  the model limit, retries with exponential backoff on transient Pluggy/network
  errors, then chains AI categorization. Daily incremental beat sync (3-day
  window, 05:00 São Paulo) + `celery_beat` service in docker-compose.
- **Fail-safe request paths**: date params validated (400), Pluggy failures map
  to 502, broker-down maps to 503 in production; the inline import fallback is
  DEBUG-only so a 90-day import can never run inside a gunicorn request in prod.
  Celery publish now fails fast (~2s, was ~19s/call) when the broker is missing.
- **AI cache key**: hashed (cache-backend safe) on description + amount sign —
  income and expense with identical descriptions no longer share a category.
- **Dev tooling**: `tools/pluggy-connect/` — a served widget page exercising the
  full flow against the sandbox (also the reference for the Phase 3 web UI).

## Test plan

- 65 backend tests green (`pytest`), all changes test-first.
- Live E2E against the Pluggy sandbox: login → connect token → Connect widget
  (Pluggy Bank, `user-ok`) → ownership check → 2 accounts + 16 transactions
  imported → AI-categorized via `gpt-4.1-mini` (real OpenAI call).
- Adversarially reviewed by a 20-agent workflow; every confirmed finding fixed
  in this PR (production inline-sync gate, date validation, retry/backoff,
  IntegrityError race, error mapping, tools-page polling).

## Follow-ups (tracked in docs/revival-plan.md, Phase 3 | 3.0)

- Migrate to cursor-based `GET /v2/transactions` before Pluggy removes the
  page-based endpoint on **2026-12-31**.
- Task-status endpoint for the `202 {task_id}` responses; Pluggy webhooks;
  income category in the taxonomy.